### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "data-fornix-web-api": "0.0.4",
     "data-fornix-web-dc": "0.0.4",
     "i": "^0.3.6",
-    "npm": "^6.9.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1"


### PR DESCRIPTION

Hello sanjayRanosys!

It seems like you have npm as one of your (dev-) dependency in react-dc-demo.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
